### PR TITLE
Respond to the Configuration update

### DIFF
--- a/src/Microsoft.Framework.ConfigurationModel.UserSecrets/ConfigurationExtensions.cs
+++ b/src/Microsoft.Framework.ConfigurationModel.UserSecrets/ConfigurationExtensions.cs
@@ -1,10 +1,9 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using Microsoft.Framework.ConfigurationModel.UserSecrets;
 using Microsoft.Framework.Internal;
-using Microsoft.Framework.Runtime;
-using Microsoft.Framework.Runtime.Infrastructure;
 
 namespace Microsoft.Framework.ConfigurationModel
 {
@@ -17,8 +16,15 @@ namespace Microsoft.Framework.ConfigurationModel
         /// <returns></returns>
         public static IConfigurationSourceRoot AddUserSecrets([NotNull]this IConfigurationSourceRoot configuration)
         {
-            var appEnv = (IApplicationEnvironment)CallContextServiceLocator.Locator.ServiceProvider.GetService(typeof(IApplicationEnvironment));
-            var secretPath = PathHelper.GetSecretsPath(appEnv.ApplicationBasePath);
+            if (string.IsNullOrEmpty(configuration.BasePath))
+            {
+                throw new InvalidOperationException(Resources.FormatError_MissingBasePath(
+                    configuration.BasePath,
+                    typeof(IConfigurationSourceRoot).Name,
+                    nameof(configuration.BasePath)));
+            }
+
+            var secretPath = PathHelper.GetSecretsPath(configuration.BasePath);
             return configuration.AddJsonFile(secretPath, optional: true);
         }
 

--- a/src/Microsoft.Framework.ConfigurationModel.UserSecrets/Properties/Resources.Designer.cs
+++ b/src/Microsoft.Framework.ConfigurationModel.UserSecrets/Properties/Resources.Designer.cs
@@ -27,6 +27,22 @@ namespace Microsoft.Framework.ConfigurationModel.UserSecrets
         }
 
         /// <summary>
+        /// Unable to resolve path '{0}'; construct this {1} with a non-null {2}.
+        /// </summary>
+        internal static string Error_MissingBasePath
+        {
+            get { return GetString("Error_MissingBasePath"); }
+        }
+
+        /// <summary>
+        /// Unable to resolve path '{0}'; construct this {1} with a non-null {2}.
+        /// </summary>
+        internal static string FormatError_MissingBasePath(object p0, object p1, object p2)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("Error_MissingBasePath"), p0, p1, p2);
+        }
+
+        /// <summary>
         /// Unable to locate a project.json at '{0}'.
         /// </summary>
         internal static string Error_Missing_Project_Json

--- a/src/Microsoft.Framework.ConfigurationModel.UserSecrets/Resources.resx
+++ b/src/Microsoft.Framework.ConfigurationModel.UserSecrets/Resources.resx
@@ -120,6 +120,9 @@
   <data name="Error_Invalid_Character_In_UserSecrets_Id" xml:space="preserve">
     <value>Invalid character '{0}' found in 'userSecretsId' value at index '{1}'.</value>
   </data>
+  <data name="Error_MissingBasePath" xml:space="preserve">
+    <value>Unable to resolve path '{0}'; construct this {1} with a non-null {2}.</value>
+  </data>
   <data name="Error_Missing_Project_Json" xml:space="preserve">
     <value>Unable to locate a project.json at '{0}'.</value>
   </data>

--- a/test/SecretManager.Tests/ConfigurationExtensionTests.cs
+++ b/test/SecretManager.Tests/ConfigurationExtensionTests.cs
@@ -28,13 +28,7 @@ namespace Microsoft.Framework.ConfigurationModel.UserSecrets.Tests
             var backupServiceProvider = CallContextServiceLocator.Locator.ServiceProvider;
             try
             {
-                CallContextServiceLocator.Locator.ServiceProvider = new ServiceCollection()
-                    .AddInstance<IApplicationEnvironment>(new MyApplicationEnvironment(appBasePath: projectPath))
-                    .BuildServiceProvider();
-
-                var configuration = new Configuration()
-                                    .AddUserSecrets();
-
+                var configuration = new Configuration(projectPath).AddUserSecrets();
                 Assert.Equal(null, configuration["Facebook:AppSecret"]);
             }
             finally
@@ -59,12 +53,7 @@ namespace Microsoft.Framework.ConfigurationModel.UserSecrets.Tests
             var backupServiceProvider = CallContextServiceLocator.Locator.ServiceProvider;
             try
             {
-                CallContextServiceLocator.Locator.ServiceProvider = new ServiceCollection()
-                    .AddInstance<IApplicationEnvironment>(new MyApplicationEnvironment(appBasePath: projectPath))
-                    .BuildServiceProvider();
-
-                var configuration = new Configuration()
-                                    .AddUserSecrets();
+                var configuration = new Configuration(projectPath).AddUserSecrets();
 
                 Assert.Equal("value1", configuration["Facebook:AppSecret"]);
             }

--- a/test/SecretManager.Tests/ConfigurationExtensionTests.cs
+++ b/test/SecretManager.Tests/ConfigurationExtensionTests.cs
@@ -2,10 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Runtime.Versioning;
-using Microsoft.Framework.DependencyInjection;
-using Microsoft.Framework.Runtime;
-using Microsoft.Framework.Runtime.Infrastructure;
 using SecretManager;
 using SecretManager.Tests;
 using Xunit;
@@ -65,55 +61,6 @@ namespace Microsoft.Framework.ConfigurationModel.UserSecrets.Tests
 
             Assert.Equal("value1", configuration["Facebook:AppSecret"]);
             UserSecretHelper.DeleteTempSecretProject(projectPath);
-        }
-
-        private class MyApplicationEnvironment : IApplicationEnvironment
-        {
-            private readonly string _appBasePath;
-            public MyApplicationEnvironment(string appBasePath)
-            {
-                _appBasePath = appBasePath;
-            }
-
-            public string ApplicationBasePath
-            {
-                get
-                {
-                    return _appBasePath;
-                }
-            }
-
-            public string ApplicationName
-            {
-                get
-                {
-                    throw new NotImplementedException();
-                }
-            }
-
-            public string Configuration
-            {
-                get
-                {
-                    throw new NotImplementedException();
-                }
-            }
-
-            public FrameworkName RuntimeFramework
-            {
-                get
-                {
-                    throw new NotImplementedException();
-                }
-            }
-
-            public string Version
-            {
-                get
-                {
-                    throw new NotImplementedException();
-                }
-            }
         }
     }
 }

--- a/test/SecretManager.Tests/ConfigurationExtensionTests.cs
+++ b/test/SecretManager.Tests/ConfigurationExtensionTests.cs
@@ -25,16 +25,9 @@ namespace Microsoft.Framework.ConfigurationModel.UserSecrets.Tests
         public void AddUserSecrets_Does_Not_Fail_On_Non_Existing_File()
         {
             var projectPath = UserSecretHelper.GetTempSecretProject();
-            var backupServiceProvider = CallContextServiceLocator.Locator.ServiceProvider;
-            try
-            {
-                var configuration = new Configuration(projectPath).AddUserSecrets();
-                Assert.Equal(null, configuration["Facebook:AppSecret"]);
-            }
-            finally
-            {
-                CallContextServiceLocator.Locator.ServiceProvider = backupServiceProvider;
-            }
+
+            var configuration = new Configuration(projectPath).AddUserSecrets();
+            Assert.Equal(null, configuration["Facebook:AppSecret"]);
 
             UserSecretHelper.DeleteTempSecretProject(projectPath);
         }
@@ -50,17 +43,8 @@ namespace Microsoft.Framework.ConfigurationModel.UserSecrets.Tests
 
             secretManager.Main(new string[] { "set", "Facebook:AppSecret", "value1", "-p", projectPath });
 
-            var backupServiceProvider = CallContextServiceLocator.Locator.ServiceProvider;
-            try
-            {
-                var configuration = new Configuration(projectPath).AddUserSecrets();
-
-                Assert.Equal("value1", configuration["Facebook:AppSecret"]);
-            }
-            finally
-            {
-                CallContextServiceLocator.Locator.ServiceProvider = backupServiceProvider;
-            }
+            var configuration = new Configuration(projectPath).AddUserSecrets();
+            Assert.Equal("value1", configuration["Facebook:AppSecret"]);
 
             UserSecretHelper.DeleteTempSecretProject(projectPath);
         }

--- a/test/SecretManager.Tests/project.json
+++ b/test/SecretManager.Tests/project.json
@@ -1,7 +1,6 @@
 ﻿{
     "dependencies": {
         "SecretManager": "1.0.0-*",
-        "Microsoft.Framework.DependencyInjection": "1.0.0-*",
         "xunit.runner.aspnet": "2.0.0-aspnet-*"
     },
     "frameworks": {


### PR DESCRIPTION
Decouples from DependencyInjection. Rather than searching for
IApplicationEnvironment instance, the BasePath on IConfigurationSourceRoot
is used to locate user secrets when user secrets id is not given.

https://github.com/aspnet/Configuration/pull/175