### PR TITLE
Use Formatted Message

### DIFF
--- a/src/SecretManager/Program.cs
+++ b/src/SecretManager/Program.cs
@@ -199,7 +199,7 @@ namespace SecretManager
             {
                 foreach (var secret in secrets)
                 {
-                    Logger.LogInformation(Resources.Message_Secret_Value_Format, secret.Key, secret.Value);
+                    Logger.LogInformation(Resources.FormatMessage_Secret_Value_Format(secret.Key, secret.Value));
                 }
             }
         }


### PR DESCRIPTION
This fix a test failure on volatile feed.

The root of the issue is in this Logging change: https://github.com/aspnet/Logging/commit/3a59b603f50ff0a8092de5a90764c43b1ddcdbd7

It breaks the C# 6 string interpolation feature.