### PR TITLE
Using 'nameof' operator instead of magic strings

### DIFF
--- a/src/SecretManager/Program.cs
+++ b/src/SecretManager/Program.cs
@@ -31,7 +31,7 @@ namespace SecretManager
             {
                 if (value == null)
                 {
-                    throw new ArgumentNullException("value");
+                    throw new ArgumentNullException(nameof(value));
                 }
 
                 _logger = value;
@@ -45,7 +45,7 @@ namespace SecretManager
             {
                 if (value == null)
                 {
-                    throw new ArgumentNullException("value");
+                    throw new ArgumentNullException(nameof(value));
                 }
 
                 _loggerProvider = value;


### PR DESCRIPTION
Using the "nameof" operator instead of magic string will help us if the variable change in the future for whatever the reason