### PR TITLE
Add System.Reflection.Extensions dependency to TestHost

### DIFF
--- a/src/Microsoft.Extensions.SecretManager/project.json
+++ b/src/Microsoft.Extensions.SecretManager/project.json
@@ -23,7 +23,8 @@
         "dnx451": { },
         "dnxcore50": {
             "dependencies": {
-                "System.Console": "4.0.0-beta-*"
+                "System.Console": "4.0.0-beta-*",
+                "System.Reflection.Extensions": "4.0.1-beta-*"
             }
         }
     }


### PR DESCRIPTION
This fixes a build error related to missing 'GetCustomAttributes'