### PR TITLE
React to configuration files no longer support absolute paths

### DIFF
--- a/src/Microsoft.Extensions.Configuration.UserSecrets/PathHelper.cs
+++ b/src/Microsoft.Extensions.Configuration.UserSecrets/PathHelper.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Extensions.Configuration.UserSecrets
 {
     public class PathHelper
     {
-        private const string Secrets_File_Name = "secrets.json";
+        internal const string Secrets_File_Name = "secrets.json";
 
         public static string GetSecretsPath(string projectPath)
         {


### PR DESCRIPTION
We might want to revisit how things work with absolute paths, but this restores the old behavior with absolute paths for user secrets.

cc @divega 