### PR TITLE
Move BasePath logic into UserSecrets

### DIFF
--- a/src/Microsoft.Extensions.Configuration.UserSecrets/ConfigurationExtensions.cs
+++ b/src/Microsoft.Extensions.Configuration.UserSecrets/ConfigurationExtensions.cs
@@ -11,6 +11,58 @@ namespace Microsoft.Extensions.Configuration
     public static class ConfigurationExtensions
     {
         private const string Secrets_File_Name = "secrets.json";
+        private const string ProjectPathKey = "ProjectPath";
+
+        /// <summary>
+        /// Gets the project path
+        /// </summary>
+        /// <param name="configurationBuilder">The <see cref="IConfigurationBuilder"/> to add to.</param>
+        /// <returns>The project path.</returns>
+        public static string GetProjectPath(this IConfigurationBuilder configurationBuilder)
+        {
+            if (configurationBuilder == null)
+            {
+                throw new ArgumentNullException(nameof(configurationBuilder));
+            }
+
+            object projectPath;
+            if (configurationBuilder.Properties.TryGetValue(ProjectPathKey, out projectPath))
+            {
+                return (string)projectPath;
+            }
+
+#if NET451
+            var stringBasePath = AppDomain.CurrentDomain.GetData("APP_CONTEXT_BASE_DIRECTORY") as string ??
+                AppDomain.CurrentDomain.BaseDirectory ??
+                string.Empty;
+
+            return Path.GetFullPath(stringBasePath);
+#else
+            return AppContext.BaseDirectory ?? string.Empty;
+#endif
+        }
+
+        /// <summary>
+        /// Sets the project path.
+        /// </summary>
+        /// <param name="builder">The <see cref="IConfigurationBuilder"/> to add to.</param>
+        /// <param name="projectPath">The absolute path of file-based providers.</param>
+        /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
+        public static IConfigurationBuilder SetProjectPath(this IConfigurationBuilder builder, string projectPath)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            if (projectPath == null)
+            {
+                throw new ArgumentNullException(nameof(projectPath));
+            }
+
+            builder.Properties[ProjectPathKey] = projectPath;
+            return builder;
+        }
 
         /// <summary>
         /// Adds the user secrets configuration source.
@@ -24,15 +76,15 @@ namespace Microsoft.Extensions.Configuration
                 throw new ArgumentNullException(nameof(configuration));
             }
 
-            if (string.IsNullOrEmpty(configuration.GetBasePath()))
+            var projectPath = configuration.GetProjectPath();
+            if (string.IsNullOrEmpty(projectPath))
             {
                 throw new InvalidOperationException(Resources.FormatError_MissingBasePath(
-                    configuration.GetBasePath(),
-                    typeof(IConfigurationBuilder).Name,
-                    "BasePath"));
+                        projectPath,
+                        typeof(IConfigurationBuilder).Name,
+                        ProjectPathKey));
             }
-
-            return AddSecretsFile(configuration, PathHelper.GetSecretsPath(configuration.GetBasePath()));
+            return AddSecretsFile(configuration, PathHelper.GetSecretsPath(projectPath));
         }
 
         /// <summary>

--- a/test/Microsoft.Extensions.SecretManager.Tests/ConfigurationExtensionTests.cs
+++ b/test/Microsoft.Extensions.SecretManager.Tests/ConfigurationExtensionTests.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Extensions.Configuration.UserSecrets.Tests
         {
             var projectPath = UserSecretHelper.GetTempSecretProject();
 
-            var builder = new ConfigurationBuilder().SetBasePath(projectPath).AddUserSecrets();
+            var builder = new ConfigurationBuilder().SetProjectPath(projectPath).AddUserSecrets();
             var configuration = builder.Build();
             Assert.Equal(null, configuration["Facebook:AppSecret"]);
 
@@ -48,7 +48,8 @@ namespace Microsoft.Extensions.Configuration.UserSecrets.Tests
 
             secretManager.Run(new string[] { "set", "Facebook:AppSecret", "value1", "-p", projectPath });
 
-            var builder = new ConfigurationBuilder().SetBasePath(projectPath).AddUserSecrets();
+            var builder = new ConfigurationBuilder().SetProjectPath(projectPath).AddUserSecrets();
+
             var configuration = builder.Build();
             Assert.Equal("value1", configuration["Facebook:AppSecret"]);
 


### PR DESCRIPTION
cc @divega 

I couldn't add an overload since there already was one that took a string, so I went with the extension methods for Get/SetProjectPath