### PR TITLE
Make ConfigurationExtensions partial

### DIFF
--- a/src/Microsoft.Extensions.Configuration.UserSecrets/ConfigurationExtensions.cs
+++ b/src/Microsoft.Extensions.Configuration.UserSecrets/ConfigurationExtensions.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.FileProviders;
 
 namespace Microsoft.Extensions.Configuration
 {
-    public static class ConfigurationExtensions
+    public static partial class ConfigurationExtensions
     {
         private const string Secrets_File_Name = "secrets.json";
 


### PR DESCRIPTION
Make ConfigurationExtensions partial to avoid conflict with Extensions.Configuration.Abstractions. Proposed fix for https://github.com/aspnet/Configuration/issues/490. See also my pull request for https://github.com/aspnet/Configuration which does the same thing to the latter.