### PR TITLE
Increase .travis.yml consistency between repos

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,9 @@ addons:
     - libunwind8
     - zlib1g
 env:
-  - KOREBUILD_DNU_RESTORE_CORECLR=true
+  global:
+    - DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+    - DOTNET_CLI_TELEMETRY_OPTOUT: 1
 mono:
   - 4.0.5
 os:


### PR DESCRIPTION
- aspnet/Universe#349
- minimize `dotnet` setup time; no need for caching
- `KOREBUILD_DNU_RESTORE_CORECLR` env variable isn't used anymore