### PR TITLE
Make the file storing 'userSecretsId' configurable by assembly attribute

### DIFF
--- a/src/Microsoft.Extensions.Configuration.UserSecrets/ConfigurationExtensions.cs
+++ b/src/Microsoft.Extensions.Configuration.UserSecrets/ConfigurationExtensions.cs
@@ -3,15 +3,19 @@
 
 using System;
 using System.IO;
+using System.Reflection;
 using Microsoft.Extensions.Configuration.UserSecrets;
+using Microsoft.Extensions.Configuration.UserSecrets.Internal;
 using Microsoft.Extensions.FileProviders;
 
 namespace Microsoft.Extensions.Configuration
 {
+    /// <summary>
+    /// Configuration extensions for adding user secrets configuration source.
+    /// </summary>
     public static class ConfigurationExtensions
     {
-        private const string Secrets_File_Name = "secrets.json";
-
+#if NET451 || NETSTANDARD1_5
         /// <summary>
         /// Adds the user secrets configuration source.
         /// </summary>
@@ -24,9 +28,51 @@ namespace Microsoft.Extensions.Configuration
                 throw new ArgumentNullException(nameof(configuration));
             }
 
-            var fileProvider = configuration.GetFileProvider();
+            return AddUserSecrets(configuration, Assembly.GetEntryAssembly());
+        }
+#endif
 
-            return AddSecretsFile(configuration, PathHelper.GetSecretsPath(fileProvider));
+        /// <summary>
+        /// Adds the user secrets configuration source.
+        /// </summary>
+        /// <remarks>
+        /// The assembly containing <typeparamref name="TStartup" /> should define an instance of <see cref="UserSecretsIdentifierFileNameAttribute" />
+        /// </remarks>
+        /// <typeparam name="TStartup">The startup type to use</typeparam>
+        /// <param name="configuration"></param>
+        /// <returns></returns>
+        public static IConfigurationBuilder AddUserSecrets<TStartup>(this IConfigurationBuilder configuration)
+        {
+            if (configuration == null)
+            {
+                throw new ArgumentNullException(nameof(configuration));
+            }
+
+            return AddUserSecrets(configuration, typeof(TStartup).GetTypeInfo().Assembly);
+        }
+
+        /// <summary>
+        /// Adds the user secrets configuration source.
+        /// </summary>
+        /// <param name="configuration"></param>
+        /// <param name="assembly">The assembly with the <see cref="UserSecrets.UserSecretsIdentifierFileNameAttribute" /></param>
+        /// <returns></returns>
+        public static IConfigurationBuilder AddUserSecrets(this IConfigurationBuilder configuration, Assembly assembly)
+        {
+            if (configuration == null)
+            {
+                throw new ArgumentNullException(nameof(configuration));
+            }
+
+            if (assembly == null)
+            {
+                throw new ArgumentNullException(nameof(assembly));
+            }
+
+            var fileProvider = configuration.GetFileProvider();
+            var filename = assembly.GetUserSecretsFileNameOrDefault();
+
+            return AddSecretsFile(configuration, PathHelper.GetSecretsPath(fileProvider, filename));
         }
 
         /// <summary>
@@ -53,8 +99,8 @@ namespace Microsoft.Extensions.Configuration
         private static IConfigurationBuilder AddSecretsFile(IConfigurationBuilder configuration, string secretPath)
         {
             var directoryPath = Path.GetDirectoryName(secretPath);
-            var fileProvider = Directory.Exists(directoryPath) 
-                ? new PhysicalFileProvider(directoryPath) 
+            var fileProvider = Directory.Exists(directoryPath)
+                ? new PhysicalFileProvider(directoryPath)
                 : null;
             return configuration.AddJsonFile(fileProvider, PathHelper.Secrets_File_Name, optional: true, reloadOnChange: false);
         }

--- a/src/Microsoft.Extensions.Configuration.UserSecrets/ConfigurationExtensions.cs
+++ b/src/Microsoft.Extensions.Configuration.UserSecrets/ConfigurationExtensions.cs
@@ -15,12 +15,17 @@ namespace Microsoft.Extensions.Configuration
     /// </summary>
     public static class ConfigurationExtensions
     {
-#if NET451 || NETSTANDARD1_5
         /// <summary>
         /// Adds the user secrets configuration source.
         /// </summary>
+        /// <exception cref="System.PlatformNotSupportedException">
+        /// Platforms that do not support System.Reflection.Assembly.GetEntryAssembly()
+        /// </exception>
         /// <param name="configuration"></param>
         /// <returns></returns>
+#if NETSTANDARD1_3
+        [Obsolete("This method will always throw on this platform. Use the AddUserSecrets(System.Reflection.Assembly) overload instead.")]
+#endif
         public static IConfigurationBuilder AddUserSecrets(this IConfigurationBuilder configuration)
         {
             if (configuration == null)
@@ -28,9 +33,15 @@ namespace Microsoft.Extensions.Configuration
                 throw new ArgumentNullException(nameof(configuration));
             }
 
+#if NETSTANDARD1_3
+            // this was added because the 1.0, netstandard1.3 version shipped with this API
+            // but did not need to use GetEntryAssembly (netstandard1.5 and up).
+            throw new PlatformNotSupportedException(Resources.Error_EntryAssembly_NotAvailable);
+#else
+            // Assembly.GetEntryAssembly requires netstandard1.5 or desktop .NET
             return AddUserSecrets(configuration, Assembly.GetEntryAssembly());
-        }
 #endif
+        }
 
         /// <summary>
         /// Adds the user secrets configuration source.

--- a/src/Microsoft.Extensions.Configuration.UserSecrets/ConfigurationExtensions.cs
+++ b/src/Microsoft.Extensions.Configuration.UserSecrets/ConfigurationExtensions.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Extensions.Configuration
             }
 
 #if NETSTANDARD1_3
-            // this was added because the 1.0, netstandard1.3 version shipped with this API
+            // this was added because the version 1.0.0, netstandard1.3 version shipped with this API
             // but did not need to use GetEntryAssembly (netstandard1.5 and up).
             throw new PlatformNotSupportedException(Resources.Error_EntryAssembly_NotAvailable);
 #else

--- a/src/Microsoft.Extensions.Configuration.UserSecrets/ConfigurationExtensions.cs
+++ b/src/Microsoft.Extensions.Configuration.UserSecrets/ConfigurationExtensions.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Extensions.Configuration
         /// Adds the user secrets configuration source.
         /// </summary>
         /// <param name="configuration"></param>
-        /// <param name="assembly">The assembly with the <see cref="UserSecrets.UserSecretsIdentifierFileNameAttribute" /></param>
+        /// <param name="assembly">The assembly with the <see cref="UserSecretsIdentifierFileNameAttribute" /></param>
         /// <returns></returns>
         public static IConfigurationBuilder AddUserSecrets(this IConfigurationBuilder configuration, Assembly assembly)
         {

--- a/src/Microsoft.Extensions.Configuration.UserSecrets/Internal/AssemblyExtensions.cs
+++ b/src/Microsoft.Extensions.Configuration.UserSecrets/Internal/AssemblyExtensions.cs
@@ -1,0 +1,22 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Reflection;
+
+namespace Microsoft.Extensions.Configuration.UserSecrets.Internal
+{
+    internal static class AssemblyExtensions
+    {
+        public static string GetUserSecretsFileNameOrDefault(this Assembly assembly)
+        {
+            if (assembly == null)
+            {
+                throw new ArgumentNullException(nameof(assembly));
+            }
+
+            return assembly.GetCustomAttribute<UserSecretsIdentifierFileNameAttribute>()?.FileName
+                ?? UserSecretsIdentifierFileNameAttribute.DefaultIdentifierFileName;
+        }
+    }
+}

--- a/src/Microsoft.Extensions.Configuration.UserSecrets/Internal/AssemblyExtensions.cs
+++ b/src/Microsoft.Extensions.Configuration.UserSecrets/Internal/AssemblyExtensions.cs
@@ -8,6 +8,9 @@ namespace Microsoft.Extensions.Configuration.UserSecrets.Internal
 {
     internal static class AssemblyExtensions
     {
+        // Set to project.json for maximum compatibility with 1.0.0
+        private const string DefaultIdentifierFileName = "project.json";
+
         public static string GetUserSecretsFileNameOrDefault(this Assembly assembly)
         {
             if (assembly == null)
@@ -16,7 +19,7 @@ namespace Microsoft.Extensions.Configuration.UserSecrets.Internal
             }
 
             return assembly.GetCustomAttribute<UserSecretsIdentifierFileNameAttribute>()?.FileName
-                ?? UserSecretsIdentifierFileNameAttribute.DefaultIdentifierFileName;
+                ?? DefaultIdentifierFileName;
         }
     }
 }

--- a/src/Microsoft.Extensions.Configuration.UserSecrets/PathHelper.cs
+++ b/src/Microsoft.Extensions.Configuration.UserSecrets/PathHelper.cs
@@ -3,49 +3,40 @@
 
 using System;
 using System.IO;
+using System.Reflection;
+using Microsoft.Extensions.Configuration.UserSecrets.Internal;
 using Microsoft.Extensions.FileProviders;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Extensions.Configuration.UserSecrets
 {
+    /// <summary>
+    /// Utility methods for finding user secrets paths
+    /// </summary>
     public class PathHelper
     {
         internal const string Secrets_File_Name = "secrets.json";
-        internal const string Config_File_Name = "project.json";
 
+#if NET451 || NETSTANDARD1_5
+        /// <summary>
+        /// Gets the path to the secrets file. Uses the <paramref name="provider" /> and <seealso cref="Assembly.GetEntryAssembly" /> to find the user secrets id.
+        /// </summary>
+        /// <param name="provider">The file provider</param>
+        /// <returns>The filepath to secrets file</returns>
         public static string GetSecretsPath(IFileProvider provider)
         {
-            if (provider == null)
-            {
-                throw new ArgumentNullException(nameof(provider));
-            }
-
-            var fileInfo = provider.GetFileInfo(Config_File_Name);
-            if (fileInfo == null || !fileInfo.Exists || string.IsNullOrEmpty(fileInfo.PhysicalPath))
-            {
-                throw new InvalidOperationException(
-                    string.Format(Resources.Error_Missing_Project_Json, provider.GetFileInfo("/")?.PhysicalPath ?? "unknown"));
-            }
-
-            using (var stream = fileInfo.CreateReadStream())
-            using (var streamReader = new StreamReader(stream))
-            using (var jsonReader = new JsonTextReader(streamReader))
-            {
-                var obj = JObject.Load(jsonReader);
-
-                var userSecretsId = obj.Value<string>("userSecretsId");
-
-                if (string.IsNullOrEmpty(userSecretsId))
-                {
-                    throw new InvalidOperationException(
-                        string.Format(Resources.Error_Missing_UserSecretId_In_Project_Json, fileInfo.Name));
-                }
-
-                return GetSecretsPathFromSecretsId(userSecretsId);
-            }
+            return GetSecretsPath(provider, Assembly.GetEntryAssembly().GetUserSecretsFileNameOrDefault());
         }
+#endif
 
+        /// <summary>
+        /// Gets the path to the secrets file. If a directory is given, finds the user secrets id in the JSON named 'project.json'.
+        /// </summary>
+        /// <param name="projectPath"></param>
+        /// <returns>The filepath to secrets file</returns>
+        // TODO remove in 2.0
+        [Obsolete("This API will be removed in future releases. Use PathHelper.GetSecretsPath(rootPath, identifierFileName) instead.")]
         public static string GetSecretsPath(string projectPath)
         {
             if (projectPath == null)
@@ -53,12 +44,49 @@ namespace Microsoft.Extensions.Configuration.UserSecrets
                 throw new ArgumentNullException(nameof(projectPath));
             }
 
-            using (var provider = new PhysicalFileProvider(projectPath))
+            if (Directory.Exists(projectPath))
             {
-                return GetSecretsPath(provider);
+                return GetSecretsPath(projectPath, "project.json");
+            }
+
+            return GetSecretsPath(Path.GetDirectoryName(projectPath), Path.GetFileName(projectPath));
+        }
+
+        /// <summary>
+        /// Gets the path to the secrets file. Finds the user secrets id in the JSON <paramref name="identifierFileName" />.
+        /// </summary>
+        /// <param name="rootPath">The path containing <paramref name="identifierFileName" /></param>
+        /// <param name="identifierFileName">The JSON file containing the user secrets id</param>
+        /// <returns>The filepath to secrets file</returns>
+        public static string GetSecretsPath(string rootPath, string identifierFileName)
+        {
+            if (rootPath == null)
+            {
+                throw new ArgumentNullException(nameof(rootPath));
+            }
+
+            using (var provider = new PhysicalFileProvider(rootPath))
+            {
+                return GetSecretsPath(provider, identifierFileName);
             }
         }
 
+        /// <summary>
+        /// Gets the path to the secrets file. Finds the user secrets id in the JSON <paramref name="identifierFileName" />.
+        /// </summary>
+        /// <param name="provider">The provider containing <paramref name="identifierFileName" /></param>
+        /// <param name="identifierFileName">The JSON file containing the user secrets id</param>
+        /// <returns>The filepath to secrets file</returns>
+        public static string GetSecretsPath(IFileProvider provider, string identifierFileName)
+        {
+            return GetSecretsPathFromSecretsId(GetUserSecretsIdFromFile(provider, identifierFileName));
+        }
+
+        /// <summary>
+        /// Gets the path to the secrets file.
+        /// </summary>
+        /// <param name="userSecretsId">The user secrets id</param>
+        /// <returns>The filepath to secrets file</returns>
         public static string GetSecretsPathFromSecretsId(string userSecretsId)
         {
             if (userSecretsId == null)
@@ -86,6 +114,38 @@ namespace Microsoft.Extensions.Configuration.UserSecrets
             else
             {
                 return Path.Combine(root, ".microsoft", "usersecrets", userSecretsId, Secrets_File_Name);
+            }
+        }
+
+        private static string GetUserSecretsIdFromFile(IFileProvider provider, string filename)
+        {
+            if (provider == null)
+            {
+                throw new ArgumentNullException(nameof(provider));
+            }
+
+            var fileInfo = provider.GetFileInfo(filename);
+            if (fileInfo == null || !fileInfo.Exists || string.IsNullOrEmpty(fileInfo.PhysicalPath))
+            {
+                var filePath = provider.GetFileInfo("/")?.PhysicalPath ?? "unknown";
+                throw new FileNotFoundException(string.Format(Resources.Error_Missing_Identifer_File, filePath), filePath);
+            }
+
+            using (var stream = fileInfo.CreateReadStream())
+            using (var streamReader = new StreamReader(stream))
+            using (var jsonReader = new JsonTextReader(streamReader))
+            {
+                var obj = JObject.Load(jsonReader);
+
+                var userSecretsId = obj.Value<string>("userSecretsId");
+
+                if (string.IsNullOrEmpty(userSecretsId))
+                {
+                    throw new InvalidOperationException(
+                        string.Format(Resources.Error_Missing_UserSecretId_In_Json, fileInfo.PhysicalPath));
+                }
+
+                return userSecretsId;
             }
         }
     }

--- a/src/Microsoft.Extensions.Configuration.UserSecrets/PathHelper.cs
+++ b/src/Microsoft.Extensions.Configuration.UserSecrets/PathHelper.cs
@@ -22,12 +22,12 @@ namespace Microsoft.Extensions.Configuration.UserSecrets
         /// Gets the path to the secrets file. Uses the <paramref name="provider" /> and the entry assembly to find the user secrets id.
         /// </summary>
         /// <exception cref="System.PlatformNotSupportedException">
-        /// Platforms that do not support System.Reflection.Assembly.GetEntryAssembly()
+        /// Platforms that do not support System.Reflection.Assembly.GetEntryAssembly().
         /// </exception>
         /// <param name="provider">The file provider</param>
         /// <returns>The filepath to secrets file</returns>
 #if NETSTANDARD1_3
-        [Obsolete("This method will always throw on this platform. Use PathHelper.GetSecretsPath(IFileProvider provider, string identifierFileName) method instead.")]
+        [Obsolete("This method is obsolete and will be removed in a future version. This method will always throw an exception on this platform. The recommended alternative is Microsoft.Extensions.Configuration.UserSecrets.PathHelper.GetSecretsPath(IFileProvider, string).")]
 #endif
         public static string GetSecretsPath(IFileProvider provider)
         {
@@ -41,12 +41,17 @@ namespace Microsoft.Extensions.Configuration.UserSecrets
         }
 
         /// <summary>
-        /// Gets the path to the secrets file. If a directory is given, finds the user secrets id in the JSON named 'project.json'.
+        ///     <para>
+        ///     This method is obsolete and will be removed in a future version. The recommended alternative is Microsoft.Extensions.Configuration.UserSecrets.PathHelper.GetSecretsPath(string, string).
+        ///     </para>
+        ///     <para>
+        ///     Gets the path to the secrets file. If a directory is given, finds the user secrets id in the JSON named 'project.json'.
+        ///     </para>
         /// </summary>
         /// <param name="projectPath"></param>
         /// <returns>The filepath to secrets file</returns>
         // TODO remove in 2.0
-        [Obsolete("This API will be removed in future releases. Use PathHelper.GetSecretsPath(rootPath, identifierFileName) instead.")]
+        [Obsolete("This method is obsolete and will be removed in a future version. The recommended alternative is Microsoft.Extensions.Configuration.UserSecrets.PathHelper.GetSecretsPath(string, string).")]
         public static string GetSecretsPath(string projectPath)
         {
             if (projectPath == null)
@@ -135,10 +140,10 @@ namespace Microsoft.Extensions.Configuration.UserSecrets
             }
 
             var fileInfo = provider.GetFileInfo(filename);
-            if (fileInfo == null || !fileInfo.Exists || string.IsNullOrEmpty(fileInfo.PhysicalPath))
+            if (fileInfo == null)
             {
                 var filePath = provider.GetFileInfo("/")?.PhysicalPath ?? "unknown";
-                throw new FileNotFoundException(string.Format(Resources.Error_Missing_Identifer_File, filePath), filePath);
+                throw new FileNotFoundException(string.Format(Resources.Error_Missing_Identifer_File, filePath), filename);
             }
 
             using (var stream = fileInfo.CreateReadStream())

--- a/src/Microsoft.Extensions.Configuration.UserSecrets/PathHelper.cs
+++ b/src/Microsoft.Extensions.Configuration.UserSecrets/PathHelper.cs
@@ -18,17 +18,27 @@ namespace Microsoft.Extensions.Configuration.UserSecrets
     {
         internal const string Secrets_File_Name = "secrets.json";
 
-#if NET451 || NETSTANDARD1_5
         /// <summary>
-        /// Gets the path to the secrets file. Uses the <paramref name="provider" /> and <seealso cref="Assembly.GetEntryAssembly" /> to find the user secrets id.
+        /// Gets the path to the secrets file. Uses the <paramref name="provider" /> and the entry assembly to find the user secrets id.
         /// </summary>
+        /// <exception cref="System.PlatformNotSupportedException">
+        /// Platforms that do not support System.Reflection.Assembly.GetEntryAssembly()
+        /// </exception>
         /// <param name="provider">The file provider</param>
         /// <returns>The filepath to secrets file</returns>
+#if NETSTANDARD1_3
+        [Obsolete("This method will always throw on this platform. Use PathHelper.GetSecretsPath(IFileProvider provider, string identifierFileName) method instead.")]
+#endif
         public static string GetSecretsPath(IFileProvider provider)
         {
+#if NETSTANDARD1_3
+            // this was added because the 1.0, netstandard1.3 version shipped with this API
+            // but did not need to use GetEntryAssembly (netstandard1.5 and up).
+            throw new PlatformNotSupportedException(Resources.Error_EntryAssembly_NotAvailable);
+#else
             return GetSecretsPath(provider, Assembly.GetEntryAssembly().GetUserSecretsFileNameOrDefault());
-        }
 #endif
+        }
 
         /// <summary>
         /// Gets the path to the secrets file. If a directory is given, finds the user secrets id in the JSON named 'project.json'.

--- a/src/Microsoft.Extensions.Configuration.UserSecrets/Properties/Resources.Designer.cs
+++ b/src/Microsoft.Extensions.Configuration.UserSecrets/Properties/Resources.Designer.cs
@@ -58,6 +58,22 @@ namespace Microsoft.Extensions.Configuration.UserSecrets
             return string.Format(CultureInfo.CurrentCulture, GetString("Error_Missing_UserSecretId_In_Json"), p0);
         }
 
+        /// <summary>
+        /// This platform cannot identify the entry assembly. Use the overload .AddUserSecrets(System.Reflection.Assembly) instead.
+        /// </summary>
+        internal static string Error_EntryAssembly_NotAvailable
+        {
+            get { return GetString("Error_EntryAssembly_NotAvailable"); }
+        }
+
+        /// <summary>
+        /// This platform cannot identify the entry assembly. Use the overload .AddUserSecrets(System.Reflection.Assembly) instead.
+        /// </summary>
+        internal static string FormatError_EntryAssembly_NotAvailable()
+        {
+            return GetString("Error_EntryAssembly_NotAvailable");
+        }
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/Microsoft.Extensions.Configuration.UserSecrets/Properties/Resources.Designer.cs
+++ b/src/Microsoft.Extensions.Configuration.UserSecrets/Properties/Resources.Designer.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Extensions.Configuration.UserSecrets
         }
 
         /// <summary>
-        /// This platform cannot identify the entry assembly. Use the overload .AddUserSecrets(System.Reflection.Assembly) instead.
+        /// This platform cannot identify the entry assembly.
         /// </summary>
         internal static string Error_EntryAssembly_NotAvailable
         {
@@ -67,7 +67,7 @@ namespace Microsoft.Extensions.Configuration.UserSecrets
         }
 
         /// <summary>
-        /// This platform cannot identify the entry assembly. Use the overload .AddUserSecrets(System.Reflection.Assembly) instead.
+        /// This platform cannot identify the entry assembly.
         /// </summary>
         internal static string FormatError_EntryAssembly_NotAvailable()
         {

--- a/src/Microsoft.Extensions.Configuration.UserSecrets/Properties/Resources.Designer.cs
+++ b/src/Microsoft.Extensions.Configuration.UserSecrets/Properties/Resources.Designer.cs
@@ -27,35 +27,35 @@ namespace Microsoft.Extensions.Configuration.UserSecrets
         }
 
         /// <summary>
-        /// Unable to locate a project.json at '{0}'.
+        /// Unable to locate load the user secrets identifier file '{0}'.
         /// </summary>
-        internal static string Error_Missing_Project_Json
+        internal static string Error_Missing_Identifer_File
         {
-            get { return GetString("Error_Missing_Project_Json"); }
+            get { return GetString("Error_Missing_Identifer_File"); }
         }
 
         /// <summary>
-        /// Unable to locate a project.json at '{0}'.
+        /// Unable to locate load the user secrets identifier file '{0}'.
         /// </summary>
-        internal static string FormatError_Missing_Project_Json(object p0)
+        internal static string FormatError_Missing_Identifer_File(object p0)
         {
-            return string.Format(CultureInfo.CurrentCulture, GetString("Error_Missing_Project_Json"), p0);
-        }
-
-        /// <summary>
-        /// Missing 'userSecretsId' in '{0}'.
-        /// </summary>
-        internal static string Error_Missing_UserSecretId_In_Project_Json
-        {
-            get { return GetString("Error_Missing_UserSecretId_In_Project_Json"); }
+            return string.Format(CultureInfo.CurrentCulture, GetString("Error_Missing_Identifer_File"), p0);
         }
 
         /// <summary>
         /// Missing 'userSecretsId' in '{0}'.
         /// </summary>
-        internal static string FormatError_Missing_UserSecretId_In_Project_Json(object p0)
+        internal static string Error_Missing_UserSecretId_In_Json
         {
-            return string.Format(CultureInfo.CurrentCulture, GetString("Error_Missing_UserSecretId_In_Project_Json"), p0);
+            get { return GetString("Error_Missing_UserSecretId_In_Json"); }
+        }
+
+        /// <summary>
+        /// Missing 'userSecretsId' in '{0}'.
+        /// </summary>
+        internal static string FormatError_Missing_UserSecretId_In_Json(object p0)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("Error_Missing_UserSecretId_In_Json"), p0);
         }
 
         private static string GetString(string name, params string[] formatterNames)

--- a/src/Microsoft.Extensions.Configuration.UserSecrets/Resources.resx
+++ b/src/Microsoft.Extensions.Configuration.UserSecrets/Resources.resx
@@ -127,6 +127,6 @@
     <value>Missing 'userSecretsId' in '{0}'.</value>
   </data>
   <data name="Error_EntryAssembly_NotAvailable">
-    <value>This platform cannot identify the entry assembly. Use the overload .AddUserSecrets(System.Reflection.Assembly) instead.</value>
+    <value>This platform cannot identify the entry assembly.</value>
   </data>
 </root>

--- a/src/Microsoft.Extensions.Configuration.UserSecrets/Resources.resx
+++ b/src/Microsoft.Extensions.Configuration.UserSecrets/Resources.resx
@@ -126,4 +126,7 @@
   <data name="Error_Missing_UserSecretId_In_Json" xml:space="preserve">
     <value>Missing 'userSecretsId' in '{0}'.</value>
   </data>
+  <data name="Error_EntryAssembly_NotAvailable">
+    <value>This platform cannot identify the entry assembly. Use the overload .AddUserSecrets(System.Reflection.Assembly) instead.</value>
+  </data>
 </root>

--- a/src/Microsoft.Extensions.Configuration.UserSecrets/Resources.resx
+++ b/src/Microsoft.Extensions.Configuration.UserSecrets/Resources.resx
@@ -121,7 +121,7 @@
     <value>Invalid character '{0}' found in 'userSecretsId' value at index '{1}'.</value>
   </data>
   <data name="Error_Missing_Identifer_File" xml:space="preserve">
-    <value>Unable to locate load the user secrets identifier file '{0}'.</value>
+    <value>Unable to locate the user secrets identifier file '{0}'.</value>
   </data>
   <data name="Error_Missing_UserSecretId_In_Json" xml:space="preserve">
     <value>Missing 'userSecretsId' in '{0}'.</value>

--- a/src/Microsoft.Extensions.Configuration.UserSecrets/Resources.resx
+++ b/src/Microsoft.Extensions.Configuration.UserSecrets/Resources.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -120,10 +120,10 @@
   <data name="Error_Invalid_Character_In_UserSecrets_Id" xml:space="preserve">
     <value>Invalid character '{0}' found in 'userSecretsId' value at index '{1}'.</value>
   </data>
-  <data name="Error_Missing_Project_Json" xml:space="preserve">
-    <value>Unable to locate a project.json at '{0}'.</value>
+  <data name="Error_Missing_Identifer_File" xml:space="preserve">
+    <value>Unable to locate load the user secrets identifier file '{0}'.</value>
   </data>
-  <data name="Error_Missing_UserSecretId_In_Project_Json" xml:space="preserve">
+  <data name="Error_Missing_UserSecretId_In_Json" xml:space="preserve">
     <value>Missing 'userSecretsId' in '{0}'.</value>
   </data>
 </root>

--- a/src/Microsoft.Extensions.Configuration.UserSecrets/UserSecretsIdentifierFilenameAttribute.cs
+++ b/src/Microsoft.Extensions.Configuration.UserSecrets/UserSecretsIdentifierFilenameAttribute.cs
@@ -18,9 +18,6 @@ namespace Microsoft.Extensions.Configuration.UserSecrets
     [AttributeUsage(AttributeTargets.Assembly, Inherited = false, AllowMultiple = false)]
     public class UserSecretsIdentifierFileNameAttribute : Attribute
     {
-        // Set to project.json for maximum compatibility with 1.0.0
-        internal const string DefaultIdentifierFileName = "project.json";
-
         /// <summary>
         /// Initializes an instance of <see cref="UserSecretsIdentifierFileNameAttribute" />
         /// </summary>
@@ -31,9 +28,12 @@ namespace Microsoft.Extensions.Configuration.UserSecrets
         }
 
         /// <summary>
-        /// The filename of the JSON file that stores the user secret id
+        /// The filename of the JSON file that stores the user secret id.
+        /// <remarks>
+        /// This can be null or empty. Callers should check the value before using.
+        /// </remarks>
         /// </summary>
-        /// <returns>The filename</returns>
-        public string FileName { get; } = DefaultIdentifierFileName;
+        /// <returns>The file name</returns>
+        public string FileName { get; set; }
     }
 }

--- a/src/Microsoft.Extensions.Configuration.UserSecrets/UserSecretsIdentifierFilenameAttribute.cs
+++ b/src/Microsoft.Extensions.Configuration.UserSecrets/UserSecretsIdentifierFilenameAttribute.cs
@@ -1,0 +1,39 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Reflection;
+
+namespace Microsoft.Extensions.Configuration.UserSecrets
+{
+    /// <summary>
+    ///     <para>
+    ///     Represents the filename that <see cref="ConfigurationExtensions.AddUserSecrets(IConfigurationBuilder, Assembly)" /> will load to find the user secret identifier.
+    ///     </para>
+    ///     <para>
+    ///     The identifer file should be a JSON file with a top-level key 'userSecretsId' with string value. The value identifies the configuration source of
+    ///     user secrets that configuration should load.
+    ///     </para>
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Assembly, Inherited = false, AllowMultiple = false)]
+    public class UserSecretsIdentifierFileNameAttribute : Attribute
+    {
+        // Set to project.json for maximum compatibility with 1.0.0
+        internal const string DefaultIdentifierFileName = "project.json";
+
+        /// <summary>
+        /// Initializes an instance of <see cref="UserSecretsIdentifierFileNameAttribute" />
+        /// </summary>
+        /// <param name="fileName">The filename (relative path)</param>
+        public UserSecretsIdentifierFileNameAttribute(string fileName)
+        {
+            FileName = fileName;
+        }
+
+        /// <summary>
+        /// The filename of the JSON file that stores the user secret id
+        /// </summary>
+        /// <returns>The filename</returns>
+        public string FileName { get; } = DefaultIdentifierFileName;
+    }
+}

--- a/src/Microsoft.Extensions.Configuration.UserSecrets/project.json
+++ b/src/Microsoft.Extensions.Configuration.UserSecrets/project.json
@@ -3,9 +3,6 @@
   "buildOptions": {
     "warningsAsErrors": true,
     "keyFile": "../../tools/Key.snk",
-    "nowarn": [
-      "CS1591"
-    ],
     "xmlDoc": true
   },
   "description": "User secrets configuration provider implementation for Microsoft.Extensions.Configuration.",
@@ -25,6 +22,7 @@
   },
   "frameworks": {
     "net451": {},
-    "netstandard1.3": {}
+    "netstandard1.3": {},
+    "netstandard1.5": {}
   }
 }

--- a/src/Microsoft.Extensions.SecretManager.Tools/Program.cs
+++ b/src/Microsoft.Extensions.SecretManager.Tools/Program.cs
@@ -227,7 +227,7 @@ namespace Microsoft.Extensions.SecretManager.Tools
         private void ProcessSecretFile(string projectPath, Action<IDictionary<string, string>> observer, bool persist = true)
         {
             Logger.LogDebug(Resources.Message_Project_File_Path, projectPath);
-            var secretsFilePath = PathHelper.GetSecretsPath(projectPath);
+            var secretsFilePath = PathHelper.GetSecretsPath(projectPath, "project.json");
             Logger.LogDebug(Resources.Message_Secret_File_Path, secretsFilePath);
             var secrets = new ConfigurationBuilder()
                 .AddJsonFile(secretsFilePath, optional: true, reloadOnChange: false)
@@ -247,7 +247,7 @@ namespace Microsoft.Extensions.SecretManager.Tools
         private void ClearSecretFile(string projectPath)
         {
             Logger.LogDebug(Resources.Message_Project_File_Path, projectPath);
-            var secretsFilePath = PathHelper.GetSecretsPath(projectPath);
+            var secretsFilePath = PathHelper.GetSecretsPath(projectPath, "project.json");
             Logger.LogDebug(Resources.Message_Secret_File_Path, secretsFilePath);
 
             WriteSecretsFile(secretsFilePath, secrets: null);

--- a/test/Microsoft.Extensions.Configuration.UserSecrets.Tests/PathHelperTests.cs
+++ b/test/Microsoft.Extensions.Configuration.UserSecrets.Tests/PathHelperTests.cs
@@ -14,7 +14,12 @@ namespace Microsoft.Extensions.Configuration.UserSecrets.Tests
         {
             string userSecretsId;
             var projectPath = UserSecretHelper.GetTempSecretProject(out userSecretsId);
+
+            // intentionally test obsolete API to ensure behavior still works
+            // TODO Remove in 2.0
+            #pragma warning disable CS0618
             var actualSecretPath = PathHelper.GetSecretsPath(projectPath);
+            #pragma warning restore CS0618
 
             var root = Environment.GetEnvironmentVariable("APPDATA") ??         // On Windows it goes to %APPDATA%\Microsoft\UserSecrets\
                         Environment.GetEnvironmentVariable("HOME");             // On Mac/Linux it goes to ~/.microsoft/usersecrets/
@@ -34,9 +39,9 @@ namespace Microsoft.Extensions.Configuration.UserSecrets.Tests
             var projectPath = UserSecretHelper.GetTempSecretProject();
             File.Delete(Path.Combine(projectPath, "project.json"));
 
-            Assert.Throws<InvalidOperationException>(() =>
+            Assert.Throws<FileNotFoundException>(() =>
             {
-                PathHelper.GetSecretsPath(projectPath);
+                PathHelper.GetSecretsPath(projectPath, "project.json");
             });
 
             UserSecretHelper.DeleteTempSecretProject(projectPath);
@@ -50,7 +55,7 @@ namespace Microsoft.Extensions.Configuration.UserSecrets.Tests
 
             Assert.Throws<InvalidOperationException>(() =>
             {
-                PathHelper.GetSecretsPath(projectPath);
+                PathHelper.GetSecretsPath(projectPath, "project.json");
             });
 
             UserSecretHelper.DeleteTempSecretProject(projectPath);
@@ -66,7 +71,7 @@ namespace Microsoft.Extensions.Configuration.UserSecrets.Tests
                 UserSecretHelper.SetTempSecretInProject(projectPath, "Test" + character);
                 Assert.Throws<InvalidOperationException>(() =>
                 {
-                    PathHelper.GetSecretsPath(projectPath);
+                    PathHelper.GetSecretsPath(projectPath, "project.json");
                 });
             }
 

--- a/test/Microsoft.Extensions.SecretManager.Tools.Tests/SecretManagerTests.cs
+++ b/test/Microsoft.Extensions.SecretManager.Tools.Tests/SecretManagerTests.cs
@@ -138,14 +138,14 @@ namespace Microsoft.Extensions.SecretManager.Tests
             secretManager.Run(new string[] { "-v", "set", "secret1", "value1", "-p", projectPath });
             Assert.Equal(3, logger.Messages.Count);
             Assert.Contains(string.Format("Project file path {0}.", projectPath), logger.Messages);
-            Assert.Contains(string.Format("Secrets file path {0}.", PathHelper.GetSecretsPath(projectPath)), logger.Messages);
+            Assert.Contains(string.Format("Secrets file path {0}.", PathHelper.GetSecretsPath(projectPath, "project.json")), logger.Messages);
             Assert.Contains("Successfully saved secret1 = value1 to the secret store.", logger.Messages);
             logger.Messages.Clear();
 
             secretManager.Run(new string[] { "-v", "list", "-p", projectPath });
             Assert.Equal(3, logger.Messages.Count);
             Assert.Contains(string.Format("Project file path {0}.", projectPath), logger.Messages);
-            Assert.Contains(string.Format("Secrets file path {0}.", PathHelper.GetSecretsPath(projectPath)), logger.Messages);
+            Assert.Contains(string.Format("Secrets file path {0}.", PathHelper.GetSecretsPath(projectPath, "project.json")), logger.Messages);
             Assert.Contains("secret1 = value1", logger.Messages);
 
             UserSecretHelper.DeleteTempSecretProject(projectPath);
@@ -184,7 +184,7 @@ namespace Microsoft.Extensions.SecretManager.Tests
         public void List_Flattens_Nested_Objects()
         {
             var projectPath = UserSecretHelper.GetTempSecretProject();
-            var secretsFile = PathHelper.GetSecretsPath(projectPath);
+            var secretsFile = PathHelper.GetSecretsPath(projectPath, "project.json");
             Directory.CreateDirectory(Path.GetDirectoryName(secretsFile));
             File.WriteAllText(secretsFile, @"{ ""AzureAd"": { ""ClientSecret"": ""abcdéƒ©˙î""} }", Encoding.UTF8);
             var logger = new TestLogger();
@@ -200,7 +200,7 @@ namespace Microsoft.Extensions.SecretManager.Tests
         public void Set_Flattens_Nested_Objects()
         {
             var projectPath = UserSecretHelper.GetTempSecretProject();
-            var secretsFile = PathHelper.GetSecretsPath(projectPath);
+            var secretsFile = PathHelper.GetSecretsPath(projectPath, "project.json");
             Directory.CreateDirectory(Path.GetDirectoryName(secretsFile));
             File.WriteAllText(secretsFile, @"{ ""AzureAd"": { ""ClientSecret"": ""abcdéƒ©˙î""} }", Encoding.UTF8);
             var logger = new TestLogger();


### PR DESCRIPTION
The runtime piece of #96.

Obsoletes `PathHelper.GetSecretsPath(string projectPath)` in favor of `PathHelper.GetSecretsPath(string rootDir, string identifierFileName)`. Will add a TODO to remove this API in 2.0.

NB: this is backwards compatible by defaulting to a json file named "project.json".

cc @glennc @davidfowl @muratg 