### PR TITLE
Create msbuild targets to generate UserSecretsIdentifierFileNameAttribute

### DIFF
--- a/src/Microsoft.Extensions.Configuration.UserSecrets/build/netstandard1.0/Microsoft.Extensions.Configuration.UserSecrets.targets
+++ b/src/Microsoft.Extensions.Configuration.UserSecrets/build/netstandard1.0/Microsoft.Extensions.Configuration.UserSecrets.targets
@@ -1,0 +1,46 @@
+<!--
+Copyright (c) .NET Foundation. All rights reserved.
+Licensed under the Apache License, Version 2.0.
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <GeneratedUserSecretsAttributeFile Condition="'$(GeneratedUserSecretsAttributeFile)'==''">$(IntermediateOutputPath)UserSecretsAssemblyInfo$(DefaultLanguageSourceExtension)</GeneratedUserSecretsAttributeFile>
+    <GenerateUserSecretsAttribute Condition="'$(GenerateUserSecretsAttribute)'==''">true</GenerateUserSecretsAttribute>
+  </PropertyGroup>
+
+<!--
+**********************************************************************************
+Target: GenerateUserSecretsAttribute
+
+Generates an assembly attribute that can change the default JSON file
+.AddUserSecrets will read from to find userSecretsId
+
+**********************************************************************************
+-->
+  <Target Name="GenerateUserSecretsAttribute"
+          BeforeTargets="CoreCompile"
+          DependsOnTargets="PrepareForBuild;CoreGenerateUserSecretsAttribute"
+          Condition="'$(GenerateUserSecretsAttribute)'=='true' and '$(UserSecretIdentifierFile)'!='' and '$(DesignTimeBuild)'!='true'"
+          Inputs="$(MSBuildAllProjects)"
+          Outputs="$(GeneratedUserSecretsAttributeFile)" />
+
+  <Target Name="CoreGenerateUserSecretsAttribute">
+    <ItemGroup>
+      <_UserSecretAssemblyAttribute Remove="@(_UserSecretAssemblyAttribute)" />
+      <_UserSecretAssemblyAttribute Include="Microsoft.Extensions.Configuration.UserSecrets.UserSecretsIdentifierFileNameAttribute">
+        <_Parameter1>$(UserSecretIdentifierFile)</_Parameter1>
+      </_UserSecretAssemblyAttribute>
+    </ItemGroup>
+
+    <ItemGroup>
+      <!--Ensure generated file is not already in compile sources-->
+      <Compile Remove="$(GeneratedUserSecretsAttributeFile)"  />
+    </ItemGroup>
+
+    <WriteCodeFragment AssemblyAttributes="@(_UserSecretAssemblyAttribute)" Language="$(Language)" OutputFile="$(GeneratedUserSecretsAttributeFile)">
+      <Output TaskParameter="OutputFile" ItemName="Compile" />
+      <Output TaskParameter="OutputFile" ItemName="FileWrites" />
+    </WriteCodeFragment>
+  </Target>
+</Project>

--- a/src/Microsoft.Extensions.Configuration.UserSecrets/project.json
+++ b/src/Microsoft.Extensions.Configuration.UserSecrets/project.json
@@ -18,7 +18,10 @@
       "configuration",
       "secrets",
       "usersecrets"
-    ]
+    ],
+    "files": {
+      "include": "build/**/*"
+    }
   },
   "dependencies": {
     "Microsoft.Extensions.Configuration.Json": "1.1.0-*"


### PR DESCRIPTION
Depends on #103 

Add MSBuild target to `Microsoft.Extensions.Configuration.UserSecrets` to automate generating `[assembly: UserSecretsIdentifierFileNameAttribute("filename.json")]` on build.

This allows user to set a property `UserSecretIdentifierFile` in their csproj to configure the filename used by `.AddUserSecrets()`.

Cref #96

cc @glennc @davidfowl @muratg 